### PR TITLE
Run DuckDB queries in parallel

### DIFF
--- a/duckdb/src/main/java/com/ldbc/impls/workloads/ldbc/snb/duckdb/DuckDbConnectionState.java
+++ b/duckdb/src/main/java/com/ldbc/impls/workloads/ldbc/snb/duckdb/DuckDbConnectionState.java
@@ -20,7 +20,6 @@ public class DuckDbConnectionState<TDbQueryStore extends QueryStore> extends Bas
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         connection = DriverManager.getConnection("jdbc:duckdb:scratch/ldbc.duckdb");
         Statement statement = connection.createStatement();
-        statement.execute("PRAGMA threads=1;");
     }
 
     public Connection getConnection() throws DbException {


### PR DESCRIPTION
Will fix #209 which is blocked on https://github.com/duckdb/duckdb/issues/2709

Once it's released (e.g. as DuckDB 0.3.x), bump the DuckDB version in this repository accordingly.